### PR TITLE
Feature/사용자 패턴 추가 가능으로 확장성 강화

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Acacian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -147,3 +147,7 @@ graph TD
     EVAL --> MR
 
 ```
+## 📝 License
+
+
+This project is licensed under the [MIT License](./LICENSE) © 2025 Acacian

--- a/dsl-core/src/main/kotlin/com/ktpattern/patternmatch/PatternEvaluator.kt
+++ b/dsl-core/src/main/kotlin/com/ktpattern/patternmatch/PatternEvaluator.kt
@@ -1,5 +1,6 @@
 package com.ktpattern.patternmatch
 
 interface PatternEvaluator<T> {
+    fun supports(pattern: Pattern<*>): Boolean
     fun evaluate(pattern: Pattern<T>, value: T): PatternMatchResult
 }

--- a/dsl-dsl/src/main/kotlin/com/ktpattern/patternmatch/match.kt
+++ b/dsl-dsl/src/main/kotlin/com/ktpattern/patternmatch/match.kt
@@ -7,16 +7,13 @@ inline fun <reified T, R> match(
     snapshotBinder: SnapshotBinder? = null,
     block: MatchBuilder<T, R>.() -> Unit
 ): R? {
-    val rawEvaluator = ServiceLoader.load(PatternEvaluator::class.java)
-        .firstOrNull() as? PatternEvaluator<Any>
-        ?: error("No PatternEvaluator found via ServiceLoader")
+    val evaluators = ServiceLoader.load(PatternEvaluator::class.java).toList()
 
-    @Suppress("UNCHECKED_CAST")
-    val evaluator = rawEvaluator as PatternEvaluator<T>
+    val builder: MatchBuilder<T, R> = MatchBuilder(
+        CompositeEvaluator(evaluators),
+        snapshotBinder
+    )
 
-    val builder: MatchBuilder<T, R> = MatchBuilder(evaluator, snapshotBinder)
     builder.block()
-
-    val result: R? = builder.evaluate(value)
-    return result
+    return builder.evaluate(value)
 }

--- a/dsl-dsl/src/main/kotlin/com/ktpattern/patternmatch/match.kt
+++ b/dsl-dsl/src/main/kotlin/com/ktpattern/patternmatch/match.kt
@@ -2,18 +2,20 @@ package com.ktpattern.patternmatch
 
 import java.util.ServiceLoader
 
+@Suppress("UNCHECKED_CAST")
 inline fun <reified T, R> match(
     value: T,
     snapshotBinder: SnapshotBinder? = null,
     block: MatchBuilder<T, R>.() -> Unit
-): R? {
-    val evaluators = ServiceLoader.load(PatternEvaluator::class.java).toList()
+): R {
+    val rawEvaluators = ServiceLoader.load(PatternEvaluator::class.java).toList()
+    val typedEvaluators = rawEvaluators.map { it as PatternEvaluator<T> }
 
     val builder: MatchBuilder<T, R> = MatchBuilder(
-        CompositeEvaluator(evaluators),
+        CompositeEvaluator(typedEvaluators),
         snapshotBinder
     )
 
     builder.block()
-    return builder.evaluate(value)
+    return builder.evaluate(value)!!
 }

--- a/dsl-runtime/src/main/kotlin/com/ktpattern/patternmatch/CompositeEvaluator.kt
+++ b/dsl-runtime/src/main/kotlin/com/ktpattern/patternmatch/CompositeEvaluator.kt
@@ -1,0 +1,13 @@
+package com.ktpattern.patternmatch
+
+class CompositeEvaluator(
+    private val delegates: List<PatternEvaluator<Any>>
+) : PatternEvaluator<Any> {
+    override fun supports(pattern: Pattern<*>): Boolean = true
+
+    override fun evaluate(pattern: Pattern<Any>, value: Any): PatternMatchResult {
+        val evaluator = delegates.firstOrNull { it.supports(pattern) }
+            ?: error("❌ No evaluator supports this pattern: $pattern")
+        return evaluator.evaluate(pattern, value)
+    }
+}

--- a/dsl-runtime/src/main/kotlin/com/ktpattern/patternmatch/CompositeEvaluator.kt
+++ b/dsl-runtime/src/main/kotlin/com/ktpattern/patternmatch/CompositeEvaluator.kt
@@ -1,13 +1,15 @@
 package com.ktpattern.patternmatch
 
-class CompositeEvaluator(
-    private val delegates: List<PatternEvaluator<Any>>
-) : PatternEvaluator<Any> {
+class CompositeEvaluator<T>(
+    private val delegates: List<PatternEvaluator<T>>
+) : PatternEvaluator<T> {
+
     override fun supports(pattern: Pattern<*>): Boolean = true
 
-    override fun evaluate(pattern: Pattern<Any>, value: Any): PatternMatchResult {
+    override fun evaluate(pattern: Pattern<T>, value: T): PatternMatchResult {
         val evaluator = delegates.firstOrNull { it.supports(pattern) }
             ?: error("❌ No evaluator supports this pattern: $pattern")
+
         return evaluator.evaluate(pattern, value)
     }
 }

--- a/dsl-runtime/src/main/kotlin/com/ktpattern/patternmatch/DefaultPatternEvaluator.kt
+++ b/dsl-runtime/src/main/kotlin/com/ktpattern/patternmatch/DefaultPatternEvaluator.kt
@@ -1,6 +1,13 @@
 package com.ktpattern.patternmatch
 
 internal class DefaultPatternEvaluator : PatternEvaluator<Any> {
+    override fun supports(pattern: Pattern<*>): Boolean {
+        return pattern is TypePattern<*> ||
+                pattern is ValuePattern<*> ||
+                pattern is DestructurePattern<*> ||
+                pattern is PredicateCondition<*>
+    }
+
     @Suppress("UNCHECKED_CAST")
     override fun evaluate(pattern: Pattern<Any>, value: Any): PatternMatchResult {
         return when (pattern) {


### PR DESCRIPTION
## Goal

패턴 매칭 DSL의 평가 로직을 고정된 evaluator에 의존하지 않고,  
**사용자가 직접 구현한 evaluator(패턴 평가자)를 외부 모듈로부터 동적으로 로딩하여 사용할 수 있도록 확장**하였습니다.

이를 통해 사용자는 `RegexPattern`, `RangePattern`, `JsonFieldPattern` 등  
자신만의 DSL 패턴을 정의하고, DSL 본체를 수정하지 않아도 `case(...)` 구문을 그대로 활용할 수 있습니다.

이 구조는 이후 다음과 같은 확장 기반이 됩니다:

- 도메인별 DSL 패턴 모듈 구성 (`kt-pattern-regex`, `kt-pattern-xml`, `kt-pattern-json` 등)
- Spring 또는 Ktor 연계 시 커스텀 evaluator 자동 주입
- 사용자 정의 evaluator (예: AI 기반 평가, DB 패턴 평가 등)

---

## Change

- `PatternEvaluator<T>` 인터페이스에 `supports(pattern: Pattern<*>)` 함수 추가  
  → evaluator가 처리할 수 있는 패턴을 명시적으로 선언 가능

- `CompositeEvaluator` 도입  
  → 등록된 evaluator 목록 중 supports 조건에 맞는 evaluator를 자동 선택하여 평가 수행

- `ServiceLoader` 기반 evaluator 등록 구조 반영  
  → 외부 모듈에서 evaluator를 `META-INF/services/...`에 등록하면 DSL에서 자동 인식 가능

- `match()` 함수 내부 evaluator 선택 로직을 `CompositeEvaluator` 기반으로 변경  
  → evaluator가 하나로 고정되지 않고, 다수 evaluator 중 조건에 맞는 것을 자동 적용

---

## Description

패턴 매칭 DSL은 이제 evaluator를 직접 고정하지 않고,  
다수 evaluator 중에서 **supports 조건을 만족하는 evaluator를 찾아 평가**하게 됩니다.

사용자는 evaluator만 정의하고, 아래와 같이 DSL에 바로 적용할 수 있습니다:

```kotlin
val pattern = RegexPattern(Regex("^hello.*"))

val result = match("hello world") {
    case(pattern) { "✅ 정규식 매칭 성공!" }
}